### PR TITLE
Depreciate IPv6 host masq IP

### DIFF
--- a/go-controller/pkg/node/gateway_init_linux_test.go
+++ b/go-controller/pkg/node/gateway_init_linux_test.go
@@ -1584,6 +1584,7 @@ var _ = Describe("Gateway unit tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			config.Kubernetes.ServiceCIDRs = []*net.IPNet{ipnet}
 			gwIPs := []net.IP{net.ParseIP("10.0.0.11")}
+			srcIP := config.Gateway.MasqueradeIPs.V4HostMasqueradeIP
 			lnk := &linkMock.Link{}
 			lnkAttr := &netlink.LinkAttrs{
 				Name:  "ens1f0",
@@ -1595,6 +1596,7 @@ var _ = Describe("Gateway unit tests", func() {
 				Scope:     netlink.SCOPE_UNIVERSE,
 				Gw:        gwIPs[0],
 				MTU:       config.Default.MTU - 100,
+				Src:       srcIP,
 			}
 
 			expectedRoute := &netlink.Route{
@@ -1603,6 +1605,7 @@ var _ = Describe("Gateway unit tests", func() {
 				Scope:     netlink.SCOPE_UNIVERSE,
 				Gw:        gwIPs[0],
 				MTU:       config.Default.MTU,
+				Src:       srcIP,
 			}
 
 			lnk.On("Attrs").Return(lnkAttr)

--- a/go-controller/pkg/node/management-port_linux.go
+++ b/go-controller/pkg/node/management-port_linux.go
@@ -185,7 +185,7 @@ func setupManagementPortIPFamilyConfig(routeManager *routemanager.Controller, mp
 		// disappearing
 		warnings = append(warnings, fmt.Sprintf("missing IP address %s on the interface %s, adding it...",
 			cfg.ifAddr, mpcfg.ifName))
-		err = util.LinkAddrAdd(mpcfg.link, cfg.ifAddr, 0)
+		err = util.LinkAddrAdd(mpcfg.link, cfg.ifAddr, 0, 0, 0)
 	}
 	if err != nil {
 		return warnings, err

--- a/go-controller/pkg/util/net_linux.go
+++ b/go-controller/pkg/util/net_linux.go
@@ -238,8 +238,8 @@ func LinkAddrExist(link netlink.Link, address *net.IPNet) (bool, error) {
 }
 
 // LinkAddrAdd removes existing addresses on the link and adds the new address
-func LinkAddrAdd(link netlink.Link, address *net.IPNet, flags int) error {
-	err := netLinkOps.AddrAdd(link, &netlink.Addr{IPNet: address, Flags: flags})
+func LinkAddrAdd(link netlink.Link, address *net.IPNet, flags, preferredLifetime, validLifetime int) error {
+	err := netLinkOps.AddrAdd(link, &netlink.Addr{IPNet: address, Flags: flags, PreferedLft: preferredLifetime, ValidLft: validLifetime})
 	if err != nil {
 		return fmt.Errorf("failed to add address %s on link %s: %v", address, link.Attrs().Name, err)
 	}

--- a/go-controller/pkg/util/net_linux_unit_test.go
+++ b/go-controller/pkg/util/net_linux_unit_test.go
@@ -326,7 +326,7 @@ func TestLinkAddrAdd(t *testing.T) {
 
 			ovntest.ProcessMockFnList(&mockNetLinkOps.Mock, tc.onRetArgsNetLinkLibOpers)
 			ovntest.ProcessMockFnList(&mockLink.Mock, tc.onRetArgsLinkIfaceOpers)
-			err := LinkAddrAdd(tc.inputLink, tc.inputNewAddr, tc.inputFlags)
+			err := LinkAddrAdd(tc.inputLink, tc.inputNewAddr, tc.inputFlags, 0, 0)
 			t.Log(err)
 			if tc.errExp {
 				assert.Error(t, err)


### PR DESCRIPTION
The host masq IP is used as src IP when a workload residing in the host net ns attempts to connect to a svc IP.

However, in the wild, we have seen users not config any routes that match a particular destination.

Then linux will use the follow src addr selection algo for IPv6:

1. Prefer same address.
2. Prefer appropriate scope.
3. Avoid deprecated addresses.
4. Prefer home addresses.
5. Prefer outgoing interface
6. Prefer matching label.
7. Prefer public addresses.
8. Use longest matching prefix.

If theres a tie break, linux uses the latest address added, and that can end up being the host masq IP.

We want to only use the host masq IP if the dst is a a service IP and never use it otherwise.

We cannot change the scope of the address because the host IP masq IP falls within the global scope range as defined by IANA special registry.

Depreciating the address was not meant for this purpose but it achieve this goal as long as we have the correct routes configured.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->